### PR TITLE
Hide enchantment description

### DIFF
--- a/src/main/java/com/shweit/pollmaster/commands/pollDetailsCommand/PollDetailsCommand.java
+++ b/src/main/java/com/shweit/pollmaster/commands/pollDetailsCommand/PollDetailsCommand.java
@@ -11,6 +11,7 @@ import org.bukkit.OfflinePlayer;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 
@@ -80,11 +81,12 @@ public final class PollDetailsCommand {
             questionLore.add(ChatColor.RED + LangUtil.getTranslation("delete_poll_lore"));
         }
         questionMeta.setLore(questionLore);
+        if (creator.getUniqueId() == player.getUniqueId()) {
+            questionMeta.addEnchant(Enchantment.UNBREAKING, 1, true);
+            questionMeta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+        }
 
         questionItem.setItemMeta(questionMeta);
-        if (creator.getUniqueId() == player.getUniqueId()) {
-            questionItem.addUnsafeEnchantment(Enchantment.UNBREAKING, 1);
-        }
 
         pollDetailsInventory.setItem(13, questionItem);
 

--- a/src/main/java/com/shweit/pollmaster/commands/pollsCommand/PollsCommand.java
+++ b/src/main/java/com/shweit/pollmaster/commands/pollsCommand/PollsCommand.java
@@ -11,6 +11,7 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemFlag;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.Material;
@@ -110,11 +111,12 @@ public final class PollsCommand implements CommandExecutor {
                 lore.add(ChatColor.RED + LangUtil.getTranslation("delete_poll_lore"));
             }
             meta.setLore(lore);
+            if (creator.getUniqueId() == player.getUniqueId()) {
+                meta.addEnchant(Enchantment.UNBREAKING, 1, true);
+                meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
+            }
 
             pollItem.setItemMeta(meta);
-            if (creator.getUniqueId() == player.getUniqueId()) {
-                pollItem.addUnsafeEnchantment(Enchantment.UNBREAKING, 1);
-            }
             pollsInventory.addItem(pollItem);
         }
 


### PR DESCRIPTION
We add an enchantment to the polls which got created by the user to help him see his own poll.

Before this PR the player could see the enchantment description, but now we hide it.